### PR TITLE
Fix AAC decoder failing to instantiate

### DIFF
--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -5331,9 +5331,7 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
                             err = mOMXNode->getParameter(
                                     (OMX_INDEXTYPE)OMX_IndexParamAudioAndroidAacDrcPresentation,
                                     &presentation, sizeof(presentation));
-                            if (err != OK) {
-                                return err;
-                            }
+                            if (err == OK) {
                             notify->setInt32("aac-encoded-target-level",
                                              presentation.nEncodedTargetLevel);
                             notify->setInt32("aac-drc-cut-level", presentation.nDrcCut);
@@ -5346,6 +5344,7 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
                             notify->setInt32("aac-drc-album-mode", presentation.nDrcAlbumMode);
                             notify->setInt32("aac-drc-output-loudness",
                                              presentation.nDrcOutputLoudness);
+			    }
                         }
                     }
                     break;


### PR DESCRIPTION
This has been caused by I50fcc5ef35cb7e96592c2267652228b5fa074ba9
Non-Android 11 vendors won't provide those calls, and will thus fail.

* fix media playback for some devices

Signed-off-by: chrisw444 <wandersonrodriguesf1@gmail.com>